### PR TITLE
fix(selectable): prevent right-click from triggering selection

### DIFF
--- a/src/Selectable.tsx
+++ b/src/Selectable.tsx
@@ -248,6 +248,10 @@ function Selectable<T>(
     };
 
     const onMouseDown = (e: MouseEvent | TouchEvent) => {
+      if (e instanceof MouseEvent && e.button !== 0) {
+        return;
+      }
+
       // disable text selection, but it will prevent default scroll behavior when mouse move, so we used `useScroll`
       e.preventDefault();
       isMouseDowning = true;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- \[ ] ✨ feat
- \[x] 🐛 fix
- \[ ] 💄 style
- \[ ] 🔨 chore
- \[ ] 📝 docs

#### 🔀 变更说明 | Description of Change

`Selectable` 内 `mousedown` 的监听事件没有过滤掉鼠标右键的情况，会导致在可选范围内右击时误开启选择模式。

